### PR TITLE
feat(ui): improve agenda clarity on detailed page

### DIFF
--- a/frontend/lygazsum/src/components/DetailedPageAgendaItemDisplay.tsx
+++ b/frontend/lygazsum/src/components/DetailedPageAgendaItemDisplay.tsx
@@ -1,6 +1,7 @@
 import { AgendaItemAnalysis, SpeakerDetail } from "@/types/analysisTypes";
 import { slugify } from "@/utils/slugify";
 import { JSX } from "react";
+import numberToChineseNumber from "@/utils/numberToChineseNumber";
 
 interface AgendaItemAnalysisDisplayProps {
   item: AgendaItemAnalysis;
@@ -77,7 +78,9 @@ export default function AgendaItemAnalysisDisplay({
         id={`${idPrefix}-item-title`}
         className="scroll-mt-22 md:scroll-mt-24"
       >
-        <h2 className={subtitleClasses}>議題摘要</h2>
+        <h2 className={subtitleClasses}>
+          討論事項{numberToChineseNumber(itemIndex + 1)}
+        </h2>
         <p className="text-base text-neutral-800 leading-[180%] md:leading-relaxed mb-4">
           {item_title}
         </p>

--- a/frontend/lygazsum/src/components/HomepageCommitteeTags.tsx
+++ b/frontend/lygazsum/src/components/HomepageCommitteeTags.tsx
@@ -2,12 +2,14 @@ import getCommitteeTag from "@/utils/getCommitteeTag";
 import { BREAKPOINT_MD } from "@/constants/breakpoints";
 interface CommitteeTagsProps {
   committeeNames: string[];
-  currentWindowWidth: number;
+  currentWindowWidth?: number;
+  isForceFullName?: boolean;
 }
 
 export default function CommitteeTags({
   committeeNames,
   currentWindowWidth,
+  isForceFullName = false,
 }: CommitteeTagsProps) {
   return (
     <div className="flex flex-wrap gap-1 md:gap-2 items-center">
@@ -19,7 +21,10 @@ export default function CommitteeTags({
             key={index}
             className={`text-xs md:text-sm px-1.5 py-1 rounded-sm text-neutral-600 ${bgColor}`}
           >
-            {currentWindowWidth > BREAKPOINT_MD ? committeeName : shortName}
+            {isForceFullName ||
+            (currentWindowWidth && currentWindowWidth > BREAKPOINT_MD)
+              ? committeeName
+              : shortName}
           </span>
         );
       })}

--- a/frontend/lygazsum/src/pages/DetailedGazettePage.tsx
+++ b/frontend/lygazsum/src/pages/DetailedGazettePage.tsx
@@ -11,6 +11,7 @@ import { useTocObserver } from "@/hooks/useTocObserver";
 import { ListBulletIcon } from "@heroicons/react/24/outline";
 import { DetailedPageSkeleton } from "@/components/feedback/DetailedPageSkeleton";
 import { ErrorDisplay } from "@/components/feedback/ErrorDisplay";
+import CommitteeTags from "@/components/HomepageCommitteeTags";
 
 /**
  * 詳細內容頁面
@@ -151,15 +152,28 @@ export default function DetailedGazettePage() {
   return (
     <div className="flex px-6 md:px-20">
       <article className="md:w-2/3 pt-10 md:mr-12">
-        {/* 標題與會議簡述 */}
+        {/* 標題、委員會標籤、開會日期、與會議簡述 */}
         <section>
-          <h1 className="text-2xl md:text-3xl font-semibold leading-snug mb-3 md:mb-6 text-neutral-900">
-            {summary_title}
-          </h1>
+          <div className="mb-3 md:mb-5">
+            <h1 className="text-2xl md:text-3xl font-semibold leading-snug pb-2 text-neutral-900">
+              {summary_title}
+            </h1>
+            <div className="flex flex-row items-center">
+              <CommitteeTags
+                committeeNames={data.committee_names}
+                isForceFullName={true}
+              />
+              <p className="text-xs md:text-sm text-neutral-600">
+                ．會議日期：{data.agenda_meeting_date}
+              </p>
+            </div>
+          </div>
+
           <p className="text-base leading-[180%] md:leading-relaxed text-neutral-800 mb-3 md:mb-6 ">
             {overall_summary_sentence}
           </p>
         </section>
+
         {/* 遍歷所有的議程項目，即一項場會議可能有多個討論事項 */}
         {agenda_items?.map((item, itemIndex) => (
           <React.Fragment key={`agenda-item-wrapper-${itemIndex}`}>

--- a/frontend/lygazsum/src/utils/numberToChineseNumber.ts
+++ b/frontend/lygazsum/src/utils/numberToChineseNumber.ts
@@ -1,0 +1,17 @@
+export default function numberToChineseNumber(number: number): string {
+  const chineseNum = [
+    "零",
+    "一",
+    "二",
+    "三",
+    "四",
+    "五",
+    "六",
+    "七",
+    "八",
+    "九",
+    "十",
+  ];
+  if (number <= 10) return chineseNum[number];
+  return number.toString();
+}

--- a/frontend/lygazsum/src/utils/tocUtils.ts
+++ b/frontend/lygazsum/src/utils/tocUtils.ts
@@ -1,6 +1,7 @@
 import { TocEntry } from "@/types/models";
 import { AnalysisResultJson } from "@/types/analysisTypes";
 import { slugify } from "@/utils/slugify";
+import numberToChineseNumber from "./numberToChineseNumber";
 
 interface GenerateTocEntriesParams {
   analysisResult: AnalysisResultJson;
@@ -29,7 +30,7 @@ export default function generateTocEntries({
     if (item.item_title) {
       tocEntries.push({
         id: `${idPrefix}-item-title`,
-        text: "議題摘要",
+        text: `討論事項${numberToChineseNumber(itemIndex + 1)}`,
         type: "entry",
       });
     }


### PR DESCRIPTION
- Adds committee tags and meeting date below the main title (h1)
- Prefixes each agenda item's title with its corresponding number (e.g., '討論事項一') and so does TOC
- Refactors the 'CommitteeTags' component with a 'isForceFullName' prop