### PR TITLE
feat: add bookmark feature and refactor gazette list item components

### DIFF
--- a/frontend/lygazsum/src/App.tsx
+++ b/frontend/lygazsum/src/App.tsx
@@ -1,10 +1,11 @@
 //frontend/lygazsum/src/App.tsx
 
 import { Outlet, ScrollRestoration } from "react-router-dom";
-import { SiteHeader } from "./components/layout/SiteHeader";
-import { SiteFooter } from "./components/layout/SiteFooter";
-import { SearchProvider } from "./context/SearchFilterContext";
-import { useScrollbarVisibility } from "./hooks/useScrollbarVisibility";
+import { SiteHeader } from "@/components/layout/SiteHeader";
+import { SiteFooter } from "@/components/layout/SiteFooter";
+import { SearchProvider } from "@/context/SearchFilterContext";
+import { BookmarkProvider } from "@/context/BookmarkContext";
+import { useScrollbarVisibility } from "@/hooks/useScrollbarVisibility";
 
 /**
  * App.tsx 主要職責：
@@ -21,12 +22,14 @@ function App() {
   return (
     <div className="flex flex-col min-h-dvh bg-neutral-50">
       <SearchProvider>
-        <SiteHeader />
-        <main className="container max-w-7xl mx-auto flex-grow">
-          <Outlet />
-        </main>
-        <SiteFooter />
-        <ScrollRestoration />
+        <BookmarkProvider>
+          <SiteHeader />
+          <main className="container max-w-7xl mx-auto flex-grow">
+            <Outlet />
+          </main>
+          <SiteFooter />
+          <ScrollRestoration />
+        </BookmarkProvider>
       </SearchProvider>
     </div>
   );

--- a/frontend/lygazsum/src/components/BookmarkButton.tsx
+++ b/frontend/lygazsum/src/components/BookmarkButton.tsx
@@ -1,0 +1,28 @@
+import { BookmarkIcon } from "@heroicons/react/24/outline";
+import { BookmarkIcon as BookmarkSolidIcon } from "@heroicons/react/24/solid";
+
+interface BookmarkButtonProps {
+  isBookmarked: boolean;
+  onClick: (event: React.MouseEvent) => void;
+}
+
+export default function BookmarkButton({
+  isBookmarked,
+  onClick,
+}: BookmarkButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center space-x-1 p-2 rounded-md hover:bg-neutral-100 cursor-pointer"
+    >
+      {isBookmarked ? (
+        <BookmarkSolidIcon className="h-5 w-5 text-neutral-600" />
+      ) : (
+        <BookmarkIcon className="h-5 w-5 text-neutral-600" />
+      )}
+      <span className="text-sm text-neutral-600">
+        {isBookmarked ? "已收藏" : "加入收藏"}
+      </span>
+    </button>
+  );
+}

--- a/frontend/lygazsum/src/components/GazetteItemsListContainer.tsx
+++ b/frontend/lygazsum/src/components/GazetteItemsListContainer.tsx
@@ -1,0 +1,72 @@
+import { ReactNode } from "react";
+import { GazetteItem } from "@/types/models";
+import { GazetteListItemSkeleton } from "@/components/feedback/GazetteListItemSkeleton";
+import { ErrorDisplay } from "@/components/feedback/ErrorDisplay";
+import { SearchFilterEmptyStateDisplay } from "@/components/feedback/SearchFilterEmptyStateDisplay";
+import { ITEM_PER_PAGE } from "@/constants/committees";
+import GazetteListItem from "./GazetteListItem";
+
+interface GazetteItemsListContainerProps {
+  items: GazetteItem[];
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  onRetry?: () => void;
+  isBookmarked: (id: string) => boolean;
+  onToggleBookmark: (id: string) => void;
+  customEmptyState?: ReactNode;
+}
+
+export default function GazetteItemsListContainer({
+  items,
+  isPending,
+  isError,
+  error,
+  onRetry,
+  isBookmarked,
+  onToggleBookmark,
+  customEmptyState,
+}: GazetteItemsListContainerProps) {
+  // 頁面載入中時，顯示 HomepageFilterButtonSkeleton 作為骨架
+  if (isPending) {
+    return (
+      <>
+        <ul className="space-y-4 mb-13 md:mb-25">
+          {Array.from({ length: ITEM_PER_PAGE }).map((_, index) => (
+            <GazetteListItemSkeleton key={index} />
+          ))}
+        </ul>
+      </>
+    );
+  }
+
+  if (isError && error) {
+    const handleRetry = onRetry || (() => {});
+    return <ErrorDisplay errorMessage={error.message} onRetry={handleRetry} />;
+  }
+
+  // 找不到數據、數據列表為空，提供 EmptyStateDisplay 作為空狀態顯示
+  if (!items || items.length === 0) {
+    return (
+      (customEmptyState && <>{customEmptyState}</>) || (
+        <SearchFilterEmptyStateDisplay />
+      )
+    );
+  }
+
+  return (
+    <div>
+      {/* 公報項目列表 */}
+      <ul className="space-y-4">
+        {items.map((item) => (
+          <GazetteListItem
+            key={item.id}
+            gazetteItem={item}
+            isBookmarked={isBookmarked(item.id)}
+            onToggleBookmark={onToggleBookmark}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/lygazsum/src/components/GazetteListItem.tsx
+++ b/frontend/lygazsum/src/components/GazetteListItem.tsx
@@ -1,19 +1,34 @@
-import { HomePageGazetteItem } from "@/types/models";
+import { GazetteItem } from "@/types/models";
 import CommitteeTags from "@/components/HomepageCommitteeTags";
 import { Link } from "react-router-dom";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { BREAKPOINT_MD } from "@/constants/breakpoints";
+import BookmarkButton from "@/components/BookmarkButton";
 
 interface GazetteListItemProps {
-  gazetteItem: HomePageGazetteItem;
+  gazetteItem: GazetteItem;
+  isBookmarked: boolean;
+  onToggleBookmark: (id: string) => void;
 }
 
-export default function GazetteListItem({ gazetteItem }: GazetteListItemProps) {
+export default function GazetteListItem({
+  gazetteItem,
+  isBookmarked,
+  onToggleBookmark,
+}: GazetteListItemProps) {
   const currentWindowWidth = useWindowSize();
 
+  // 使用 pgroonga 回傳具有高亮 keyword class 的 <span> 或使用原生 AI分析的摘要語句
   const summaryToShow = gazetteItem.highlighted_summary
     ? gazetteItem.highlighted_summary
     : gazetteItem.overall_summary_sentence;
+
+  // 傳遞 `handleBookmarkClick` 給 `BookmarkButton`
+  function handleBookmarkClick(event: React.MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    onToggleBookmark(gazetteItem.id);
+  }
 
   return (
     <li className="w-11/12 md:w-4/5 mx-auto">
@@ -30,9 +45,13 @@ export default function GazetteListItem({ gazetteItem }: GazetteListItemProps) {
             />
             <p className="text-xs md:text-sm text-neutral-600">
               {currentWindowWidth > BREAKPOINT_MD
-                ? `．會議日期：${gazetteItem.meeting_date}`
-                : `．${gazetteItem.meeting_date}`}
+                ? `．會議日期：${gazetteItem.meeting_date}．`
+                : `．${gazetteItem.meeting_date}．`}
             </p>
+            <BookmarkButton
+              isBookmarked={isBookmarked}
+              onClick={handleBookmarkClick}
+            />
           </div>
           <p
             className="text-neutral-600 text-sm leading-relaxed line-clamp-2 md:line-clamp-3"

--- a/frontend/lygazsum/src/components/feedback/FilterButtonSkeleton.tsx
+++ b/frontend/lygazsum/src/components/feedback/FilterButtonSkeleton.tsx
@@ -1,6 +1,5 @@
 export function HomepageFilterButtonSkeleton() {
   return (
-    <div className="h-9 w-24 bg-neutral-200 rounded-xl border-2 border-neutral-200 animate-pulse">
-    </div>
+    <div className="h-9 w-24 bg-neutral-200 rounded-xl border-2 border-neutral-200 animate-pulse"></div>
   );
 }

--- a/frontend/lygazsum/src/components/feedback/GenericEmptyState.tsx
+++ b/frontend/lygazsum/src/components/feedback/GenericEmptyState.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+interface GenericEmptyStateProps {
+  message: string;
+  children?: ReactNode;
+}
+
+export function GenericEmptyState({
+  message,
+  children,
+}: GenericEmptyStateProps) {
+  return (
+    <div className="flex flex-col w-3/5 mx-auto items-center justify-center text-center min-h-[calc(100vh-250px)]">
+      <p className="text-neutral-700 text-lg leading-relaxed mb-6">{message}</p>
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  );
+}

--- a/frontend/lygazsum/src/components/feedback/SearchFilterEmptyStateDisplay.tsx
+++ b/frontend/lygazsum/src/components/feedback/SearchFilterEmptyStateDisplay.tsx
@@ -1,6 +1,6 @@
-import { useSearchFilter } from "../../context/SearchFilterContext";
+import { useSearchFilter } from "@/context/SearchFilterContext";
 
-export function EmptyStateDisplay() {
+export function SearchFilterEmptyStateDisplay() {
   const { searchTerm, selectedCommittees, clearFilterAndSearchTerm } =
     useSearchFilter();
 

--- a/frontend/lygazsum/src/components/layout/SiteHeader.tsx
+++ b/frontend/lygazsum/src/components/layout/SiteHeader.tsx
@@ -82,6 +82,14 @@ export function SiteHeader() {
               <ul className="flex items-center">
                 <li>
                   <Link
+                    to="/bookmarks"
+                    className="px-2 py-2 font-medium text-neutral-700 hover:text-neutral-900 flex items-center"
+                  >
+                    我的收藏
+                  </Link>
+                </li>
+                <li>
+                  <Link
                     to="/about"
                     className="px-2 py-2 font-medium text-neutral-700 hover:text-neutral-900 flex items-center"
                   >

--- a/frontend/lygazsum/src/context/BookmarkContext.tsx
+++ b/frontend/lygazsum/src/context/BookmarkContext.tsx
@@ -1,0 +1,95 @@
+import {
+  createContext,
+  useState,
+  ReactNode,
+  useEffect,
+  useContext,
+} from "react";
+
+// 用於 localStorage 儲存公報id
+const BOOKMARKS_STORAGE_KEY = "lyzer-bookmarks";
+
+interface BookmarkContextType {
+  bookmarkedIds: string[];
+  isBookmarked: (id: string) => boolean;
+  handleBookmarkToggle: (id: string) => void;
+}
+
+const BookmarkContext = createContext<BookmarkContextType | undefined>(
+  undefined
+);
+
+interface BookmarkProviderProps {
+  children: ReactNode;
+}
+
+export function BookmarkProvider({ children }: BookmarkProviderProps) {
+  // 先抓取 localStorage 中 id 列表，若無則返回空陣列
+  const [bookmarkedIds, setBookmarkedIds] = useState<string[]>(() => {
+    try {
+      const storedIds = localStorage.getItem(BOOKMARKS_STORAGE_KEY);
+      return storedIds ? JSON.parse(storedIds) : [];
+    } catch (error) {
+      console.error("無法從 localStorage 中解析書籤id", error);
+      return [];
+    }
+  });
+
+  // 根據 id 列表，將 id 存入 localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        BOOKMARKS_STORAGE_KEY,
+        JSON.stringify(bookmarkedIds)
+      );
+    } catch (error) {
+      console.error("Failed to save bookmarks to localStorage", error);
+    }
+  }, [bookmarkedIds]);
+
+  // 判斷列表中是否含有 id，作為後續顯示 "加入收藏" 或 "取消收藏" 以及其 function
+  function isBookmarked(id: string) {
+    return bookmarkedIds.includes(id);
+  }
+
+  function addBookmark(id: string) {
+    setBookmarkedIds((prevIds) => {
+      const newIds = new Set([...prevIds, id]);
+      return Array.from(newIds);
+    });
+  }
+
+  function removeBookmark(id: string) {
+    setBookmarkedIds((prevIds) =>
+      prevIds.filter((currentId) => currentId !== id)
+    );
+  }
+
+  function handleBookmarkToggle(id: string) {
+    if (isBookmarked(id)) {
+      removeBookmark(id);
+    } else {
+      addBookmark(id);
+    }
+  }
+
+  return (
+    <BookmarkContext.Provider
+      value={{
+        bookmarkedIds,
+        isBookmarked,
+        handleBookmarkToggle,
+      }}
+    >
+      {children}
+    </BookmarkContext.Provider>
+  );
+}
+
+export function useBookmark(): BookmarkContextType {
+  const context = useContext(BookmarkContext);
+  if (context === undefined) {
+    throw new Error(" useBookmark 必須在 bookmarkProvider 中使用");
+  }
+  return context;
+}

--- a/frontend/lygazsum/src/pages/BookmarksPage.tsx
+++ b/frontend/lygazsum/src/pages/BookmarksPage.tsx
@@ -1,0 +1,52 @@
+import { useBookmark } from "@/context/BookmarkContext";
+import { useQuery } from "@tanstack/react-query";
+import { fetchGazettesByIds } from "@/services/gazetteService";
+import GazetteItemsListContainer from "@/components/GazetteItemsListContainer";
+import { GenericEmptyState } from "@/components/feedback/GenericEmptyState";
+import { Link } from "react-router-dom";
+
+export default function BookmarksPage() {
+  const { bookmarkedIds, isBookmarked, handleBookmarkToggle } = useBookmark();
+  const { data, isPending, isError, error, refetch } = useQuery({
+    queryKey: ["bookmarkedGazettes", bookmarkedIds],
+    queryFn: () => fetchGazettesByIds(bookmarkedIds),
+    enabled: bookmarkedIds.length > 0,
+  });
+
+  const actuallyLoading = bookmarkedIds.length > 0 && isPending;
+
+  const customEmptyUI = (
+    <Link
+      to="/"
+      className="inline-flex gap-x-2 rounded-xl px-5 py-2 text-neutral-700 hover:text-neutral-900 border-2 border-neutral-500 hover:border-neutral-800 transition-colors"
+    >
+      返回首頁
+    </Link>
+  );
+
+  return (
+    <div className="w-11/12 md:w-4/5 mx-auto py-8">
+      {bookmarkedIds.length > 0 && !actuallyLoading && (
+        <div className="w-11/12 md:w-4/5 mx-auto py-6">
+          <h1 className="text-2xl md:text-3xl font-semibold text-neutral-900">
+            我的收藏
+          </h1>
+        </div>
+      )}
+      <GazetteItemsListContainer
+        items={data?.itemsList || []}
+        isPending={actuallyLoading}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        isBookmarked={isBookmarked}
+        onToggleBookmark={handleBookmarkToggle}
+        customEmptyState={
+          <GenericEmptyState message="目前無收藏摘要！">
+            {customEmptyUI}
+          </GenericEmptyState>
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/lygazsum/src/pages/DetailedGazettePage.tsx
+++ b/frontend/lygazsum/src/pages/DetailedGazettePage.tsx
@@ -6,12 +6,14 @@ import { fetchDetailedGazetteById } from "@/services/gazetteService";
 import AgendaItemAnalysisDisplay from "@/components/DetailedPageAgendaItemDisplay";
 import AgendaItemMetadata from "@/components/DetailedPageMetadata";
 import { DetailedPageTableOfContent } from "@/components/DetailedPageTableOfContent";
-import generateTocEntries from "@/utils/tocUtils";
-import { useTocObserver } from "@/hooks/useTocObserver";
-import { ListBulletIcon } from "@heroicons/react/24/outline";
 import { DetailedPageSkeleton } from "@/components/feedback/DetailedPageSkeleton";
 import { ErrorDisplay } from "@/components/feedback/ErrorDisplay";
 import CommitteeTags from "@/components/HomepageCommitteeTags";
+import { useBookmark } from "@/context/BookmarkContext";
+import { useTocObserver } from "@/hooks/useTocObserver";
+import generateTocEntries from "@/utils/tocUtils";
+import { ListBulletIcon } from "@heroicons/react/24/outline";
+import BookmarkButton from "@/components/BookmarkButton";
 
 /**
  * 詳細內容頁面
@@ -23,6 +25,10 @@ export default function DetailedGazettePage() {
   const gazetteIdFromParams = params.id;
 
   const location = useLocation();
+
+  const { isBookmarked, handleBookmarkToggle } = useBookmark();
+
+  const isCurrentlyBookmarked = isBookmarked(gazetteIdFromParams!);
 
   const { isPending, isError, data, error, refetch } = useQuery<
     DetailedGazetteItem | null,
@@ -164,8 +170,12 @@ export default function DetailedGazettePage() {
                 isForceFullName={true}
               />
               <p className="text-xs md:text-sm text-neutral-600">
-                ．會議日期：{data.agenda_meeting_date}
+                ．會議日期：{data.agenda_meeting_date}．
               </p>
+              <BookmarkButton
+                isBookmarked={isCurrentlyBookmarked}
+                onClick={() => handleBookmarkToggle(gazetteIdFromParams!)}
+              />
             </div>
           </div>
 

--- a/frontend/lygazsum/src/pages/Homepage.tsx
+++ b/frontend/lygazsum/src/pages/Homepage.tsx
@@ -1,17 +1,15 @@
-import { FetchHomepageResult, SortByType } from "@/types/models";
+import { FetchGazettesListResult, SortByType } from "@/types/models";
 import { fetchHomepageGazette } from "@/services/gazetteService";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
 import { ALL_COMMITTEES_LIST, ITEM_PER_PAGE } from "@/constants/committees";
 import { useSearchFilter } from "@/context/SearchFilterContext";
+import { useBookmark } from "@/context/BookmarkContext";
 import { HomepageFilterButton } from "@/components/HomepageFilterButton";
 import { HomepagePagination } from "@/components/HomepagePagination";
-import GazetteListItem from "@/components/HomepageItemsList";
 import { useWindowSize } from "@/hooks/useWindowSize";
-import { GazetteListItemSkeleton } from "@/components/feedback/GazetteListItemSkeleton";
 import { HomepageFilterButtonSkeleton } from "@/components/feedback/FilterButtonSkeleton";
-import { ErrorDisplay } from "@/components/feedback/ErrorDisplay";
-import { EmptyStateDisplay } from "@/components/feedback/EmptyStateDisplay";
+import GazetteItemsListContainer from "@/components/GazetteItemsListContainer";
 
 /**
  * Homepage 元件
@@ -39,7 +37,7 @@ export default function Homepage() {
   const effectiveSortBy = searchTerm ? sortBy : "date_desc";
 
   const { isPending, isError, data, error, refetch, isSuccess } = useQuery<
-    FetchHomepageResult,
+    FetchGazettesListResult,
     Error
   >({
     queryKey: [
@@ -59,6 +57,8 @@ export default function Homepage() {
       }),
     staleTime: Infinity,
   });
+
+  const { isBookmarked, handleBookmarkToggle } = useBookmark();
 
   // 當有搜尋或篩選行為時，將當前頁面設定為第一頁
   useEffect(() => {
@@ -88,42 +88,13 @@ export default function Homepage() {
       });
     }
 
+    // 成功時預載
     if (isSuccess) {
       ALL_COMMITTEES_LIST.forEach((committee) => {
         prefetchFilteredCommitteeData(committee);
       });
     }
   }, [isSuccess, queryClient, searchTerm]);
-
-  // 頁面載入中時，顯示 HomepageFilterButtonSkeleton 作為骨架
-  if (isPending) {
-    return (
-      <>
-        <div className="py-4 my-2 flex justify-center">
-          <div className="inline-flex items-center space-x-3 px-2">
-            <span>委員會篩選：</span>
-            {Array.from({ length: 9 }).map((_, index) => (
-              <HomepageFilterButtonSkeleton key={index} />
-            ))}
-          </div>
-        </div>
-        <ul className="space-y-4 mb-13 md:mb-25">
-          {Array.from({ length: ITEM_PER_PAGE }).map((_, index) => (
-            <GazetteListItemSkeleton key={index} />
-          ))}
-        </ul>
-      </>
-    );
-  }
-
-  if (isError) {
-    return <ErrorDisplay errorMessage={error.message} onRetry={refetch} />;
-  }
-
-  // 找不到數據、數據列表為空，提供 EmptyStateDisplay 作為空狀態顯示
-  if (!data || data.itemsList.length === 0) {
-    return <EmptyStateDisplay />;
-  }
 
   // 處理分頁改變，於 pagination 使用
   function handlePageChange(pageNumber: number) {
@@ -135,18 +106,34 @@ export default function Homepage() {
       {/* 委員會篩選按鈕列表，共8個常設委員會 + 4個特殊委員會 */}
       <div className="flex items-center overflow-x-auto whitespace-nowrap py-4 my-2">
         <div className="space-x-3 px-2 mx-auto">
-          <span>委員會篩選：</span>
-          {ALL_COMMITTEES_LIST.map((committee) => (
-            <HomepageFilterButton
-              key={committee}
-              committeeName={committee}
-              onToggle={handleCommitteesToggle}
-              isSelected={selectedCommittees.includes(committee)}
-            />
-          ))}
+          {isPending ? (
+            // 載入時顯示篩選按鈕的骨架
+            <>
+              <div className="inline-flex items-center space-x-3 px-2">
+                <span>委員會篩選：</span>
+                {Array.from({ length: 9 }).map((_, index) => (
+                  <HomepageFilterButtonSkeleton key={index} />
+                ))}
+              </div>
+            </>
+          ) : (
+            // 載入完成後顯示真實按鈕
+            <>
+              <span>委員會篩選：</span>
+              {ALL_COMMITTEES_LIST.map((committee) => (
+                <HomepageFilterButton
+                  key={committee}
+                  committeeName={committee}
+                  onToggle={handleCommitteesToggle}
+                  isSelected={selectedCommittees.includes(committee)}
+                />
+              ))}
+            </>
+          )}
         </div>
       </div>
 
+      {/* 排序 select */}
       {searchTerm && (
         <div className="w-11/12 md:w-4/5 mx-auto flex justify-end pb-2">
           <select
@@ -155,6 +142,7 @@ export default function Homepage() {
             id="searchSortBy"
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value as SortByType)}
+            disabled={isPending}
           >
             <option value="relevance_desc">出現次數：高 → 低</option>
             <option value="relevance_asc">出現次數：低 → 高</option>
@@ -164,21 +152,27 @@ export default function Homepage() {
         </div>
       )}
 
-      {/* 公報項目列表 */}
-      <ul className="space-y-4">
-        {data.itemsList.map((gazetteItem) => (
-          <GazetteListItem key={gazetteItem.id} gazetteItem={gazetteItem} />
-        ))}
-      </ul>
+      {/* 公報項目列表容器 */}
+      <GazetteItemsListContainer
+        items={data?.itemsList || []}
+        isPending={isPending}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        isBookmarked={isBookmarked}
+        onToggleBookmark={handleBookmarkToggle}
+      />
 
       {/* 分頁元件列表 */}
-      <HomepagePagination
-        currentPage={currentPage}
-        totalItemsCount={data.totalItemsCount}
-        itemsPerPage={ITEM_PER_PAGE}
-        onPageChange={handlePageChange}
-        currentWindowWidth={currentWindowWidth}
-      />
+      {data && data.totalItemsCount > ITEM_PER_PAGE && (
+        <HomepagePagination
+          currentPage={currentPage}
+          totalItemsCount={data.totalItemsCount}
+          itemsPerPage={ITEM_PER_PAGE}
+          onPageChange={handlePageChange}
+          currentWindowWidth={currentWindowWidth}
+        />
+      )}
     </>
   );
 }

--- a/frontend/lygazsum/src/routes.tsx
+++ b/frontend/lygazsum/src/routes.tsx
@@ -2,6 +2,7 @@ import App from "./App";
 import { createBrowserRouter } from "react-router-dom";
 import Homepage from "./pages/Homepage";
 import DetailedGazettePage from "./pages/DetailedGazettePage";
+import BookmarksPage from "./pages/BookmarksPage";
 import AboutPage from "./pages/AboutPage";
 import ErrorPage from "./pages/ErrorPage";
 
@@ -18,6 +19,10 @@ export const routesConfig = createBrowserRouter([
       {
         path: "/detailedGazette/:id",
         element: <DetailedGazettePage />,
+      },
+      {
+        path: "/bookmarks",
+        element: <BookmarksPage />,
       },
       {
         path: "/about",

--- a/frontend/lygazsum/src/types/models.ts
+++ b/frontend/lygazsum/src/types/models.ts
@@ -6,7 +6,7 @@ export type SortByType =
   | "date_desc"
   | "date_asc";
 
-export interface HomePageGazetteItem {
+export interface GazetteItem {
   id: string;
   committee_names: string[];
   summary_title: string;
@@ -17,8 +17,8 @@ export interface HomePageGazetteItem {
   highlighted_summary?: string;
 }
 
-export interface FetchHomepageResult {
-  itemsList: HomePageGazetteItem[];
+export interface FetchGazettesListResult {
+  itemsList: GazetteItem[];
   totalItemsCount: number;
 }
 


### PR DESCRIPTION
Implements a client-side bookmarking feature using localStorage, allowing users to save gazette summaries. This also includes a major refactor of list rendering to improve reusability across the application.

- **Bookmark Feature:**
  - Added`BookmarkContext` for global state management of bookmarked IDs, sync them to localStorage.
  - Added new `/bookmarks` page to display saved gazette items, with a new `fetchGazettesByIds` function.
  - Added `BookmarkButton` for detailed page and list items.

- **Component & Architecture Refactor:**
  - Abstracted list rendering logic (loading, error, empty states) into `GazetteItemsListContainer`.
  - Renamed several components like `HomepageItemsList` to `GazetteListItem`.